### PR TITLE
LoongArch: Modify some type definitions

### DIFF
--- a/minidump/minidump_context.h
+++ b/minidump/minidump_context.h
@@ -641,7 +641,7 @@ struct MinidumpContextMIPS64 {
 //! Based on minidump_cpu_loongarch64.h from breakpad
 enum MinidumpContextLOONGARCH64Flags : uint32_t {
   //! \brief Identifies the context structure as LOONGARCH64.
-  kMinidumpContextLOONGARCH64 = 0x00800000,
+  kMinidumpContextLOONGARCH64 = 0x00008000,
 
   //! \brief Indicates the validity of integer registers.
   //!

--- a/minidump/minidump_extensions.h
+++ b/minidump/minidump_extensions.h
@@ -214,7 +214,7 @@ enum MinidumpCPUArchitecture : uint16_t {
   //!
   //! These systems indentify their CPUs generically as "loongarch64", or
   //! with more specific names such as "loongarch".
-  kMinidumpCPUArchitectureLOONGARCH64 = 0x8005,
+  kMinidumpCPUArchitectureLOONGARCH64 = 0x8007,
 
   //! \brief Unknown CPU architecture.
   kMinidumpCPUArchitectureUnknown = PROCESSOR_ARCHITECTURE_UNKNOWN,


### PR DESCRIPTION
Refer to the definition in breakpad, Modify the relevant type definition to make the dmp generated by crashpad can be correctly parsed by minidump_stackwalk.