### PR TITLE
LoongArch: Modify the implementation of syscallX() in lss

### DIFF
--- a/third_party/lss/lss/linux_syscall_support.h
+++ b/third_party/lss/lss/linux_syscall_support.h
@@ -3145,7 +3145,7 @@ struct kernel_statfs {
                                 "ld.d $t7, $sp, 64\n"                         \
                                 "ld.d $t8, $sp, 72\n"                         \
                                 "addi.d $sp, $sp, 80\n"                       \
-                                : "+r"(__res_a0)                              \
+                                : "=r"(__res_a0)                              \
                                 : "i"(__NR_##name) , ## args                  \
                                 : LSS_SYSCALL_CLOBBERS);                      \
           __res = __res_a0;                                                   \


### PR DESCRIPTION
There have many new failed test cases in loongnix20.6 with clang version 13.0.1-6.lnd.6. The cause of this problem is the implementation of syscallX() in the lss library. Modify it to solve this kind of problem.